### PR TITLE
[dev] Optimize macros.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "snowflaker"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chronounit",
  "ifcfg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snowflaker"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 
 authors = ["photowey <photowey@gmail.com>"]
@@ -28,5 +28,9 @@ ifcfg = "0.1"
 [features]
 dynamic = []
 
+# https://docs.rs/about/metadata
 [package.metadata.docs.rs]
+features = ["dynamic"]
+
+[package.metadata.loccal.rs]
 features = ["dynamic"]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -21,7 +21,7 @@
 #[macro_export]
 macro_rules! snowflake_builtin {
     () => {
-        next_id()
+        $crate::next_id()
     };
 }
 
@@ -30,7 +30,7 @@ macro_rules! snowflake_builtin {
 #[macro_export]
 macro_rules! snowflake_builtin_string {
     () => {
-        next_id_string()
+        $crate::next_id_string()
     };
 }
 
@@ -40,7 +40,7 @@ macro_rules! snowflake_builtin_string {
 #[cfg(feature = "dynamic")]
 macro_rules! snowflake_dynamic {
     () => {
-        dynamic_next_id()
+        $crate::dynamic_next_id()
     };
 }
 
@@ -49,6 +49,6 @@ macro_rules! snowflake_dynamic {
 #[cfg(feature = "dynamic")]
 macro_rules! snowflake_dynamic_string {
     () => {
-        dynamic_next_id_string()
+        $crate::dynamic_next_id_string()
     };
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -110,10 +110,9 @@ fn test_macro_snowflake_builtin_string() {
 #[cfg(test)]
 #[cfg(feature = "dynamic")]
 mod feature_dynamic_tests {
+    use crate::{dynamic_next_id, dynamic_next_id_string, infras};
     // @since 0.3.0
-    use crate::{dynamic_next_id, dynamic_next_id_string};
-    use crate::generator::{Constants, Generator, SnowflakeGenerator};
-    use crate::infras;
+        use crate::generator::{Constants, Generator, SnowflakeGenerator};
 
     #[test]
     fn test_try_get_data_center_id() {


### PR DESCRIPTION
- Optimize macro definitions so that there is no need to import function when using macros.
### Before
```rust
use snowflaker::{snowflake_dynamic, dynamic_next_id};
snowflake_dynamic!()
```

### After
```rust
use snowflaker::snowflake_dynamic;

snowflake_dynamic!()
```